### PR TITLE
Stabilize Flutter boot flow when restarting for new configs

### DIFF
--- a/flutter_app/lib/main.dart
+++ b/flutter_app/lib/main.dart
@@ -1,8 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:meeting_minutes_app/services/api.dart';
 import 'package:meeting_minutes_app/services/server_supervisor.dart';
-import 'package:meeting_minutes_app/pages/server_boot_page.dart';
+import 'package:meeting_minutes_app/services/transcription_config.dart';
 import 'package:meeting_minutes_app/pages/home_page.dart';
+import 'package:meeting_minutes_app/pages/model_loading_page.dart';
+import 'package:meeting_minutes_app/pages/server_boot_page.dart';
 
 void main() {
   runApp(const MyApp());
@@ -16,48 +18,120 @@ class MyApp extends StatefulWidget {
 }
 
 class _MyAppState extends State<MyApp> {
-  late final ServerSupervisor _supervisor;
-  late final BackendApi _api;
+  ServerSupervisor? _supervisor;
+  BackendApi? _api;
   bool _ready = false;
+  bool _modelReady = false;
+  int _restartToken = 0;
+  int _modelToken = 0;
+  TranscriptionConfig _config = const TranscriptionConfig();
 
   @override
   void initState() {
     super.initState();
-    _supervisor = ServerSupervisor(
-      host: '127.0.0.1',
-      port: 8000,
-      serverDir: 'server',              // ปรับเป็น absolute ได้ หรือใช้ env MEETING_APP_SERVER_DIR
-      startTimeout: const Duration(seconds: 120),
-      useReload: false,                  // ตั้ง true ถ้าต้องการ dev --reload
-    );
-    _api = BackendApi(
-      'http://127.0.0.1:8000',
-      defaultModelSize: 'large-v3',
-      defaultLanguage: 'th',
-      defaultQuality: 'accurate',
-    );
+    _recreateServices();
   }
 
   void _onServerReady() {
     setState(() {
       _ready = true;
+      _modelToken += 1;
     });
+  }
+
+  Future<void> _recreateServices([TranscriptionConfig? newConfig]) async {
+    final config = newConfig ?? _config;
+    if (_supervisor != null) {
+      await _supervisor!.stop();
+    }
+
+    final supervisor = ServerSupervisor(
+      host: '127.0.0.1',
+      port: 8000,
+      serverDir: 'server',
+      startTimeout: const Duration(seconds: 120),
+      useReload: false,
+      environmentOverrides: config.toServerEnvironment(),
+    );
+    supervisor.status.value =
+        'เตรียมเซิร์ฟเวอร์สำหรับโมเดล ${config.modelSize}...';
+    final api = BackendApi(
+      'http://127.0.0.1:8000',
+      defaultModelSize: config.modelSize,
+      defaultLanguage: config.language,
+      defaultQuality: config.quality,
+    );
+
+    setState(() {
+      _config = config;
+      _ready = false;
+      _modelReady = false;
+      _restartToken += 1;
+      _modelToken += 1;
+      _supervisor = supervisor;
+      _api = api;
+    });
+  }
+
+  void _onModelReady() {
+    if (!mounted) return;
+    setState(() {
+      _modelReady = true;
+    });
+  }
+
+  Future<void> _handleConfigChanged(TranscriptionConfig config) async {
+    if (config == _config) return;
+    await _recreateServices(config);
   }
 
   @override
   void dispose() {
-    _supervisor.stop(); // ปิดเฉพาะกรณีเราเป็นคนเปิด
+    _supervisor?.stop(); // ปิดเฉพาะกรณีเราเป็นคนเปิด
     super.dispose();
   }
 
   @override
   Widget build(BuildContext context) {
+    final supervisor = _supervisor;
+    final api = _api;
+    if (supervisor == null || api == null) {
+      return MaterialApp(
+        title: 'Meeting Minutes App',
+        theme: ThemeData(useMaterial3: true, colorSchemeSeed: Colors.blue),
+        home: const Scaffold(
+          body: Center(child: CircularProgressIndicator()),
+        ),
+      );
+    }
+
+    final Widget homeWidget;
+    if (!_ready) {
+      homeWidget = ServerBootPage(
+        key: ValueKey('boot$_restartToken'),
+        supervisor: supervisor,
+        onReady: _onServerReady,
+      );
+    } else if (!_modelReady) {
+      homeWidget = ModelLoadingPage(
+        key: ValueKey('model$_modelToken'),
+        api: api,
+        config: _config,
+        onReady: _onModelReady,
+      );
+    } else {
+      homeWidget = HomePage(
+        key: ValueKey('home$_restartToken'),
+        api: api,
+        config: _config,
+        onConfigChanged: _handleConfigChanged,
+      );
+    }
+
     return MaterialApp(
       title: 'Meeting Minutes App',
       theme: ThemeData(useMaterial3: true, colorSchemeSeed: Colors.blue),
-      home: _ready
-          ? HomePage(api: _api)
-          : ServerBootPage(supervisor: _supervisor, onReady: _onServerReady),
+      home: homeWidget,
     );
   }
 }

--- a/flutter_app/lib/pages/model_loading_page.dart
+++ b/flutter_app/lib/pages/model_loading_page.dart
@@ -1,0 +1,163 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+
+import 'package:meeting_minutes_app/services/api.dart';
+import 'package:meeting_minutes_app/services/transcription_config.dart';
+
+class ModelLoadingPage extends StatefulWidget {
+  const ModelLoadingPage({
+    super.key,
+    required this.api,
+    required this.config,
+    required this.onReady,
+  });
+
+  final BackendApi api;
+  final TranscriptionConfig config;
+  final VoidCallback onReady;
+
+  @override
+  State<ModelLoadingPage> createState() => _ModelLoadingPageState();
+}
+
+class _ModelLoadingPageState extends State<ModelLoadingPage> {
+  bool _loading = false;
+  bool _polling = false;
+  String _status = 'กำลังตรวจสอบสถานะโมเดล...';
+  String? _error;
+  List<String> _loadedModels = const [];
+
+  static const Duration _timeout = Duration(minutes: 5);
+  static const Duration _interval = Duration(seconds: 1);
+
+  @override
+  void initState() {
+    super.initState();
+    _startPolling();
+  }
+
+  Future<void> _startPolling() async {
+    if (_polling) return;
+    _polling = true;
+    setState(() {
+      _loading = true;
+      _error = null;
+      _status =
+          'กำลังโหลดโมเดล "${widget.config.modelSize}" โปรดรอสักครู่...';
+      _loadedModels = const [];
+    });
+
+    final stopwatch = Stopwatch()..start();
+    while (mounted && stopwatch.elapsed < _timeout) {
+      try {
+        final health = await widget.api.fetchHealth();
+        final defaultModel =
+            (health['default_model'] as String?)?.trim() ?? '';
+        final loaded = (health['loaded_models'] as List?)
+                ?.map((e) => e.toString())
+                .toList() ??
+            <String>[];
+        if (!mounted) {
+          _polling = false;
+          return;
+        }
+        setState(() {
+          _status = defaultModel.isEmpty
+              ? 'กำลังเตรียมโมเดลจากเซิร์ฟเวอร์...'
+              : 'โมเดลที่เซิร์ฟเวอร์กำลังกระตุ้น: $defaultModel';
+          _loadedModels = loaded;
+          _error = null;
+        });
+        if (loaded.isNotEmpty) {
+          _polling = false;
+          widget.onReady();
+          return;
+        }
+      } catch (e) {
+        if (!mounted) {
+          _polling = false;
+          return;
+        }
+        setState(() {
+          _error = 'เชื่อมต่อเซิร์ฟเวอร์ไม่ได้: $e';
+        });
+      }
+      await Future.delayed(_interval);
+    }
+
+    if (!mounted) {
+      _polling = false;
+      return;
+    }
+    setState(() {
+      _loading = false;
+      _error ??=
+          'โหลดโมเดลไม่สำเร็จภายใน ${_timeout.inMinutes} นาที โปรดลองอีกครั้งหรือเปลี่ยนการตั้งค่า';
+    });
+    _polling = false;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Center(
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: 500),
+          child: Card(
+            elevation: 2,
+            child: Padding(
+              padding: const EdgeInsets.all(20),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  const Text(
+                    'กำลังโหลดโมเดลเสียง',
+                    style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+                  ),
+                  const SizedBox(height: 12),
+                  Text('โมเดลที่เลือก: ${widget.config.modelSize}'),
+                  const SizedBox(height: 8),
+                  Text(_status),
+                  if (_loadedModels.isNotEmpty) ...[
+                    const SizedBox(height: 8),
+                    Text('โมเดลที่โหลดแล้ว (${_loadedModels.length}):'),
+                    const SizedBox(height: 4),
+                    for (final entry in _loadedModels)
+                      Padding(
+                        padding: const EdgeInsets.symmetric(vertical: 2),
+                        child: Text('• $entry'),
+                      ),
+                  ],
+                  if (_loading) ...[
+                    const SizedBox(height: 12),
+                    const LinearProgressIndicator(),
+                  ],
+                  if (_error != null) ...[
+                    const SizedBox(height: 12),
+                    Text(
+                      _error!,
+                      style: const TextStyle(color: Colors.red),
+                    ),
+                    if (!_loading) ...[
+                      const SizedBox(height: 12),
+                      Align(
+                        alignment: Alignment.centerRight,
+                        child: ElevatedButton.icon(
+                          onPressed: _startPolling,
+                          icon: const Icon(Icons.refresh),
+                          label: const Text('ลองใหม่'),
+                        ),
+                      ),
+                    ],
+                  ],
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/flutter_app/lib/pages/transcription_config_dialog.dart
+++ b/flutter_app/lib/pages/transcription_config_dialog.dart
@@ -1,0 +1,219 @@
+import 'package:flutter/material.dart';
+
+import 'package:meeting_minutes_app/services/transcription_config.dart';
+
+class TranscriptionConfigDialog extends StatefulWidget {
+  const TranscriptionConfigDialog({super.key, required this.initialConfig});
+
+  final TranscriptionConfig initialConfig;
+
+  @override
+  State<TranscriptionConfigDialog> createState() =>
+      _TranscriptionConfigDialogState();
+}
+
+class _TranscriptionConfigDialogState
+    extends State<TranscriptionConfigDialog> {
+  static const _modelPresets = <String>[
+    'tiny',
+    'base',
+    'small',
+    'medium',
+    'large-v2',
+    'large-v3',
+  ];
+
+  late String _modelSelection;
+  late String _quality;
+  late bool _preprocess;
+  late bool _fastPreprocess;
+  late TextEditingController _customModelController;
+  late TextEditingController _languageController;
+  late TextEditingController _initialPromptController;
+
+  final _formKey = GlobalKey<FormState>();
+
+  @override
+  void initState() {
+    super.initState();
+    final initial = widget.initialConfig;
+    _quality = initial.quality;
+    _preprocess = initial.preprocess;
+    _fastPreprocess = initial.fastPreprocess;
+    final isPreset = _modelPresets.contains(initial.modelSize);
+    _modelSelection = isPreset ? initial.modelSize : 'custom';
+    _customModelController = TextEditingController(
+        text: isPreset ? '' : initial.modelSize);
+    _languageController =
+        TextEditingController(text: initial.language.trim());
+    _initialPromptController =
+        TextEditingController(text: initial.initialPrompt.trim());
+  }
+
+  @override
+  void dispose() {
+    _customModelController.dispose();
+    _languageController.dispose();
+    _initialPromptController.dispose();
+    super.dispose();
+  }
+
+  void _submit() {
+    if (!_formKey.currentState!.validate()) {
+      return;
+    }
+    final language = _languageController.text.trim();
+    final initialPrompt = _initialPromptController.text.trim();
+    final selectedModel = _modelSelection == 'custom'
+        ? _customModelController.text.trim()
+        : _modelSelection;
+    final config = widget.initialConfig.copyWith(
+      modelSize: selectedModel,
+      language: language,
+      quality: _quality,
+      preprocess: _preprocess,
+      fastPreprocess: _preprocess ? _fastPreprocess : false,
+      initialPrompt: initialPrompt,
+    );
+    Navigator.of(context).pop(config);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: const Text('ปรับแต่งการถอดเสียง'),
+      content: Form(
+        key: _formKey,
+        child: SingleChildScrollView(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              DropdownButtonFormField<String>(
+                decoration: const InputDecoration(
+                  labelText: 'โมเดล (เลือก presets หรือ Custom)',
+                ),
+                value: _modelSelection,
+                items: [
+                  ..._modelPresets.map(
+                    (m) => DropdownMenuItem(
+                      value: m,
+                      child: Text(m),
+                    ),
+                  ),
+                  const DropdownMenuItem(
+                    value: 'custom',
+                    child: Text('Custom path/name'),
+                  ),
+                ],
+                onChanged: (value) {
+                  if (value == null) return;
+                  setState(() {
+                    _modelSelection = value;
+                    if (value != 'custom') {
+                      _customModelController.clear();
+                    }
+                  });
+                },
+              ),
+              if (_modelSelection == 'custom')
+                TextFormField(
+                  controller: _customModelController,
+                  decoration: const InputDecoration(
+                    labelText: 'ชื่อโมเดลหรือ path เต็ม',
+                    hintText: 'เช่น large-v3 หรือ ~/models/faster-whisper',
+                  ),
+                  validator: (value) {
+                    if (value == null || value.trim().isEmpty) {
+                      return 'กรุณากรอกชื่อโมเดลหรือ path';
+                    }
+                    return null;
+                  },
+                ),
+              const SizedBox(height: 12),
+              TextFormField(
+                controller: _languageController,
+                decoration: const InputDecoration(
+                  labelText: 'ภาษา (เช่น th, en หรือ auto)',
+                ),
+                validator: (value) {
+                  if (value == null || value.trim().isEmpty) {
+                    return 'กรุณากรอกภาษา';
+                  }
+                  return null;
+                },
+              ),
+              const SizedBox(height: 12),
+              DropdownButtonFormField<String>(
+                decoration: const InputDecoration(labelText: 'โหมดคุณภาพ'),
+                value: _quality,
+                items: const [
+                  DropdownMenuItem(value: 'accurate', child: Text('accurate')),
+                  DropdownMenuItem(value: 'balanced', child: Text('balanced')),
+                  DropdownMenuItem(value: 'fast', child: Text('fast')),
+                  DropdownMenuItem(value: 'hyperfast', child: Text('hyperfast')),
+                ],
+                onChanged: (value) {
+                  if (value == null) return;
+                  setState(() {
+                    _quality = value;
+                  });
+                },
+              ),
+              const SizedBox(height: 12),
+              SwitchListTile(
+                contentPadding: EdgeInsets.zero,
+                title: const Text('เปิดการ preprocess ด้วย ffmpeg'),
+                subtitle: const Text(
+                    'ช่วยให้เสียงมีความคงที่มากขึ้น เหมาะกับงานสำคัญ'),
+                value: _preprocess,
+                onChanged: (value) {
+                  setState(() {
+                    _preprocess = value;
+                    if (!value) {
+                      _fastPreprocess = false;
+                    }
+                  });
+                },
+              ),
+              SwitchListTile(
+                contentPadding: EdgeInsets.zero,
+                title: const Text('โหมด preprocess แบบรวดเร็ว'),
+                subtitle: const Text('ลดเวลาประมวลผล เหมาะกับการทดลองเบื้องต้น'),
+                value: _fastPreprocess,
+                onChanged: _preprocess
+                    ? (value) {
+                        setState(() {
+                          _fastPreprocess = value;
+                        });
+                      }
+                    : null,
+              ),
+              const SizedBox(height: 12),
+              TextFormField(
+                controller: _initialPromptController,
+                decoration: const InputDecoration(
+                  labelText: 'Initial prompt (ไม่บังคับ)',
+                  hintText: 'ใส่บริบทเพิ่มเติม เช่น ชื่อบริษัทหรือคำเฉพาะ',
+                ),
+                minLines: 2,
+                maxLines: 4,
+              ),
+            ],
+          ),
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: const Text('ยกเลิก'),
+        ),
+        ElevatedButton.icon(
+          onPressed: _submit,
+          icon: const Icon(Icons.save),
+          label: const Text('บันทึกและรีสตาร์ท'),
+        ),
+      ],
+    );
+  }
+}

--- a/flutter_app/lib/services/api.dart
+++ b/flutter_app/lib/services/api.dart
@@ -23,6 +23,18 @@ class BackendApi {
     print('[API] BASE URL  = ${dio.options.baseUrl}');
   }
 
+  Future<Map<String, dynamic>> fetchHealth() async {
+    final res = await dio.get('/healthz');
+    final data = res.data;
+    if (data is Map<String, dynamic>) {
+      return data;
+    }
+    if (data is Map) {
+      return data.map((key, value) => MapEntry(key.toString(), value));
+    }
+    return <String, dynamic>{};
+  }
+
   Future<FormData> _buildFormData(
     String filePath, {
     String? language,

--- a/flutter_app/lib/services/transcription_config.dart
+++ b/flutter_app/lib/services/transcription_config.dart
@@ -1,0 +1,58 @@
+class TranscriptionConfig {
+  final String modelSize;
+  final String language;
+  final String quality;
+  final bool preprocess;
+  final bool fastPreprocess;
+  final String initialPrompt;
+
+  const TranscriptionConfig({
+    this.modelSize = 'large-v3',
+    this.language = 'th',
+    this.quality = 'accurate',
+    this.preprocess = true,
+    this.fastPreprocess = false,
+    this.initialPrompt = '',
+  });
+
+  TranscriptionConfig copyWith({
+    String? modelSize,
+    String? language,
+    String? quality,
+    bool? preprocess,
+    bool? fastPreprocess,
+    String? initialPrompt,
+  }) {
+    return TranscriptionConfig(
+      modelSize: modelSize ?? this.modelSize,
+      language: language ?? this.language,
+      quality: quality ?? this.quality,
+      preprocess: preprocess ?? this.preprocess,
+      fastPreprocess: fastPreprocess ?? this.fastPreprocess,
+      initialPrompt: initialPrompt ?? this.initialPrompt,
+    );
+  }
+
+  Map<String, String> toServerEnvironment() {
+    return {
+      'WHISPER_MODEL': modelSize,
+      'WHISPER_LANG': language,
+      'WHISPER_QUALITY': quality,
+    };
+  }
+
+  @override
+  int get hashCode => Object.hash(modelSize, language, quality, preprocess,
+      fastPreprocess, initialPrompt);
+
+  @override
+  bool operator ==(Object other) {
+    return other is TranscriptionConfig &&
+        other.modelSize == modelSize &&
+        other.language == language &&
+        other.quality == quality &&
+        other.preprocess == preprocess &&
+        other.fastPreprocess == fastPreprocess &&
+        other.initialPrompt == initialPrompt;
+  }
+}


### PR DESCRIPTION
## Summary
- create server supervisor and API instances outside of setState so status updates are applied without invalid assignments
- replace the nested home ternary with explicit widget selection to avoid syntax issues when compiling on Windows

## Testing
- not run (Flutter SDK unavailable in the execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68d80cecd88c83238cfef359eebfae2a