### PR TITLE
Guard post-await actions against unmounted state

### DIFF
--- a/flutter_app/lib/pages/server_boot_page.dart
+++ b/flutter_app/lib/pages/server_boot_page.dart
@@ -28,12 +28,15 @@ class _ServerBootPageState extends State<ServerBootPage> {
     });
     try {
       await widget.supervisor.ensureStarted();
+      if (!mounted) return;
       widget.onReady();
     } catch (e) {
+      if (!mounted) return;
       setState(() {
         errorText = e.toString();
       });
     } finally {
+      if (!mounted) return;
       setState(() {
         _starting = false;
       });


### PR DESCRIPTION
## Summary
- guard server boot callbacks against running after the widget is disposed by checking `mounted`
- avoid calling `setState` when the state object is no longer active

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d8acbab6a88323a075f4b0d9aa6405